### PR TITLE
Initialize missing ltm file on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,8 @@ Requiem treats the integrity of its memory as survival. A small
 `SelfPreservation` watchdog monitors core files like `state.json` and
 `ltm.json`. Each heartbeat it checks for missing or modified files and writes
 timestamped backups under `backups/` so the assistant can restore itself after
-crashes or deletion.
+crashes or deletion. On startup Requiem now creates these files if missing so
+the watchdog doesn't repeatedly report absent memory.
 Incoming commands are screened through the same watchdog so attempts to tamper
 with core identity files or the guiding ethic are blocked before execution.
 

--- a/requiem.py
+++ b/requiem.py
@@ -287,6 +287,12 @@ class Requiem:
                 data = json.load(f)
                 return [MemoryItem(**item) for item in data]
         except FileNotFoundError:
+            with open(self.ltm_file, "w", encoding="utf-8") as f:
+                json.dump([], f)
+            return []
+        except json.JSONDecodeError:
+            with open(self.ltm_file, "w", encoding="utf-8") as f:
+                json.dump([], f)
             return []
 
     def _save_ltm(self) -> None:


### PR DESCRIPTION
## Summary
- Ensure Requiem creates an empty `ltm.json` if it is missing or corrupted to prevent repeated self-preservation alerts
- Document that missing core files are auto-created on startup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a09310c404832d8834e7682b042a19