### PR TITLE
Silence pad token warning

### DIFF
--- a/llm/hf.py
+++ b/llm/hf.py
@@ -7,6 +7,10 @@ class HuggingFaceLLM(BaseLLM):
         from transformers import pipeline  # lazy import
 
         self.pipe = pipeline("text-generation", model=model, max_new_tokens=50)
+        # Explicitly set pad token to suppress transformers warning
+        if self.pipe.model.config.pad_token_id is None:
+            self.pipe.model.config.pad_token_id = self.pipe.tokenizer.eos_token_id
+            self.pipe.tokenizer.pad_token_id = self.pipe.model.config.pad_token_id
 
     def reply(self, text: str, last_user):
         prompt = text


### PR DESCRIPTION
## Summary
- explicitly set pad token in HuggingFaceLLM to avoid noisy `pad_token_id` warnings

## Testing
- `pytest test_requiem.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a095cb1014832d852c9a6c8b40e0d6