### PR TITLE
fix: show emotion object values in web UI

### DIFF
--- a/web.py
+++ b/web.py
@@ -90,7 +90,12 @@ async function poll() {
   document.getElementById('thoughts').innerHTML = data.thoughts.map(t => `<div>${t}</div>`).join('');
   document.getElementById('actions').innerHTML = data.actions.map(a => `<div>${a}</div>`).join('');
   const status = data.status || {};
-  document.getElementById('status').innerHTML = Object.entries(status).map(([k,v]) => `<div>${k}: ${v}</div>`).join('');
+  document.getElementById('status').innerHTML = Object.entries(status)
+    .map(([k, v]) => {
+      const val = (v && typeof v === 'object') ? JSON.stringify(v) : v;
+      return `<div>${k}: ${val}</div>`;
+    })
+    .join('');
 }
 setInterval(poll, 1000);
 </script>


### PR DESCRIPTION
## Summary
- ensure status panel stringifies nested objects
- prevents `[object Object]` when displaying emotion levels

## Testing
- `pytest test_web.py -q` *(fails: terminate called without an active exception)*


------
https://chatgpt.com/codex/tasks/task_e_68a0997485ac832dac9ed3bb035852f1