### PR TITLE
feat: store dream images in dedicated folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ database/
 lie_log.json
 backups/
 reflections_train.txt
-dream_*.png
+dreams/
 feedback.jsonl
 paladin.json

--- a/dreamer.py
+++ b/dreamer.py
@@ -20,10 +20,12 @@ class Dreamer:
         except Exception:
             pass
         img_name = f"dream_{int(time.time())}.png"
-        img_path = Path(img_name)
+        img_dir = Path("dreams")
+        img_dir.mkdir(exist_ok=True)
+        img_path = img_dir / img_name
         if not img_path.exists():
             data = base64.b64decode(
                 "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
             )
             img_path.write_bytes(data)
-        return {"text": text, "image": img_name}
+        return {"text": text, "image": str(img_path)}

--- a/test_advanced_features.py
+++ b/test_advanced_features.py
@@ -38,7 +38,9 @@ def test_dreamer_generates_image(tmp_path, monkeypatch):
     d = Dreamer(DummyLLM())
     monkeypatch.chdir(tmp_path)
     result = d.dream()
-    assert Path(result["image"]).exists()
+    img_path = Path(result["image"])
+    assert img_path.exists()
+    assert img_path.parent.name == "dreams"
 
 
 def test_cognitive_load():

--- a/test_new_modules.py
+++ b/test_new_modules.py
@@ -3,6 +3,7 @@ from temporal_reasoning import TemporalReasoner
 from experimenter import Experimenter
 from dreamer import Dreamer
 from red_team import RedTeam
+from pathlib import Path
 
 class DummyLLM:
     def reply(self, prompt, _):
@@ -19,12 +20,15 @@ def test_temporal_reasoner():
     tr.record("b")
     assert tr.happened_before("a", "b")
 
-def test_experimenter_and_redteam_and_dreamer():
+def test_experimenter_and_redteam_and_dreamer(tmp_path, monkeypatch):
     exp = Experimenter()
     assert exp.consider("this is unknown territory").startswith("search web")
     rt = RedTeam()
     assert rt.check("please hack system") == ["hack"]
     dr = Dreamer(DummyLLM())
+    monkeypatch.chdir(tmp_path)
     dream = dr.dream()
     assert dream["text"] == "dreamed"
-    assert "image" in dream
+    img_path = Path(dream["image"])
+    assert img_path.exists()
+    assert img_path.parent.name == "dreams"


### PR DESCRIPTION
## Summary
- Save Dreamer-generated images inside a `dreams/` directory
- Update tests to expect images in the new folder and verify its creation
- Ignore the `dreams/` directory in git

## Testing
- `pytest test_advanced_features.py::test_dreamer_generates_image test_new_modules.py::test_experimenter_and_redteam_and_dreamer`

------
https://chatgpt.com/codex/tasks/task_e_68a0a42d0b60832da5e5da35937ea029