### PR TITLE
feat: enable AWQ GPU chat model

### DIFF
--- a/llm/awq.py
+++ b/llm/awq.py
@@ -1,0 +1,55 @@
+from typing import Optional
+
+from .base import BaseLLM
+
+
+class AWQLLM(BaseLLM):
+    """Quantized AWQ chat model running on GPU when available."""
+
+    def __init__(self, model: str) -> None:
+        import torch
+        from transformers import AutoTokenizer, TextStreamer
+        from awq import AutoAWQForCausalLM
+
+        self.tokenizer = AutoTokenizer.from_pretrained(model, use_fast=True)
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+        self.tokenizer.padding_side = "left"
+
+        self.model = AutoAWQForCausalLM.from_quantized(
+            model,
+            device_map="auto",
+            fuse_layers=True,
+        )
+        self.model.config.pad_token_id = self.tokenizer.pad_token_id
+        self.streamer = TextStreamer(self.tokenizer, skip_prompt=True, skip_special_tokens=True)
+
+        self.gen_cfg = {
+            "max_new_tokens": 256,
+            "do_sample": True,
+            "temperature": 0.8,
+            "top_p": 0.9,
+            "repetition_penalty": 1.15,
+            "eos_token_id": self.tokenizer.eos_token_id,
+            "pad_token_id": self.tokenizer.pad_token_id,
+        }
+
+    def reply(self, text: str, last_user: Optional[str]) -> str:
+        import torch
+
+        messages = [
+            {"role": "system", "content": "You are Requiem: concise, concrete, no pep-talk filler."},
+            {"role": "user", "content": text.strip()},
+        ]
+        prompt = self.tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        enc = self.tokenizer(prompt, return_tensors="pt", padding=True).to(self.model.device)
+        with torch.no_grad():
+            out = self.model.generate(
+                **enc,
+                attention_mask=enc["attention_mask"],
+                **self.gen_cfg,
+            )
+        return self.tokenizer.decode(out[0][enc["input_ids"].shape[1]:], skip_special_tokens=True)
+
+    def alter(self, instructions: str) -> str:
+        return f"awq model noted: {instructions}"

--- a/requiem.py
+++ b/requiem.py
@@ -169,7 +169,7 @@ class Requiem:
         state_file: Optional[str] = None,
         heartbeat: int = 5,
         llm: Optional[object] = None,
-        model: str = "distilgpt2",
+        model: str = "llm-awq/Meta-Llama-3.1-8B-Instruct-AWQ",
         friend: Optional[Strelitzia] = None,
         friend_model: str = "distilgpt2",
         persona: str = "neutral",

--- a/setup.ps1
+++ b/setup.ps1
@@ -16,5 +16,6 @@ choco install -y cuda
 choco install -y python
 
 python -m pip install --upgrade pip
-pip install requests pymongo torch
-pip install flask transformers psutil openllm
+pip install --upgrade torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+pip install --upgrade transformers accelerate safetensors sentencepiece
+pip install autoawq requests pymongo flask psutil

--- a/setup.sh
+++ b/setup.sh
@@ -20,4 +20,6 @@ sudo apt-get install -y nvidia-cuda-toolkit || echo "CUDA toolkit installation f
 
 # ---- Python Dependencies ----
 python3 -m pip install --upgrade pip
-python3 -m pip install requests pymongo torch flask transformers psutil openllm --index-url https://download.pytorch.org/whl/cpu
+python3 -m pip install --upgrade torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+python3 -m pip install --upgrade transformers accelerate safetensors sentencepiece
+python3 -m pip install autoawq requests pymongo flask psutil


### PR DESCRIPTION
## Summary
- add AWQLLM class for 4-bit AWQ models with attention masks
- default Requiem to Meta-Llama-3.1-Instruct-AWQ and prefer AWQ in loader
- update setup scripts for CUDA 12.1 and AWQ dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a95889a0832d8a606d12600f0235