### PR TITLE
Default to Mistral model

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,12 @@ long-term memory updates.
 
 ## LLMs
 
-Model clients live in the `llm/` directory. By default Requiem falls back to
-an echo model, but it can load any local Hugging Face model by name. All
-models run on your machine so you are free to modify them without relying on
-external APIs. If a model is unavailable the assistant tries to load a small
-one such as `distilgpt2`. Switch models at runtime with the chat command:
+Model clients live in the `llm/` directory. By default Requiem attempts to
+load a local Mistral model, falling back to an echo model if nothing else is
+available. All models run on your machine so you are free to modify them
+without relying on external APIs. If a model is unavailable the assistant
+tries to load a small one such as `distilgpt2`. Switch models at runtime with
+the chat command:
 
 ```
 set model gpt2

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -33,8 +33,8 @@ def _candidate_models(preferred: Optional[str]) -> List[str]:
     # include a quantized chat model first, then common tiny fallbacks
     candidates.extend(
         [
-            "llm-awq/Meta-Llama-3.1-8B-Instruct-AWQ",
             "TheBloke/Mistral-7B-Instruct-v0.3-AWQ",
+            "llm-awq/Meta-Llama-3.1-8B-Instruct-AWQ",
             "distilgpt2",
             "sshleifer/tiny-gpt2",
             "openlm-research/open_llama_3b",
@@ -45,7 +45,9 @@ def _candidate_models(preferred: Optional[str]) -> List[str]:
     return [m for m in candidates if not (m in seen or seen.add(m))]
 
 
-def load_llm(model: str = "llm-awq/Meta-Llama-3.1-8B-Instruct-AWQ") -> BaseLLM:
+def load_llm(
+    model: str = "TheBloke/Mistral-7B-Instruct-v0.3-AWQ",
+) -> BaseLLM:
     """Return an available language model client, preferring GPU AWQ models."""
 
     models = _candidate_models(model)

--- a/requiem.py
+++ b/requiem.py
@@ -170,7 +170,7 @@ class Requiem:
         state_file: Optional[str] = None,
         heartbeat: int = 5,
         llm: Optional[object] = None,
-        model: str = "llm-awq/Meta-Llama-3.1-8B-Instruct-AWQ",
+        model: str = "TheBloke/Mistral-7B-Instruct-v0.3-AWQ",
         friend: Optional[Strelitzia] = None,
         friend_model: str = "distilgpt2",
         persona: str = "neutral",


### PR DESCRIPTION
## Summary
- Default to the `TheBloke/Mistral-7B-Instruct-v0.3-AWQ` model when loading language models
- Prefer Mistral in the Requiem system defaults
- Update documentation to describe the new default model

## Testing
- `pytest -q` *(fails: TypeError: LieEngine.__init__() got an unexpected keyword argument 'rules_file')*

------
https://chatgpt.com/codex/tasks/task_e_68a1418e8bf0832d8e3d388dd2bfac92