### PR TITLE
Expose and display active LLM

### DIFF
--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -14,6 +14,8 @@ ALIASES = {
 class EchoLLM(BaseLLM):
     """Fallback model that simply echoes the user input."""
 
+    name = "echo"
+
     def reply(self, text: str, last_user: Optional[str]) -> str:
         prefix = f"Previously you said '{last_user}'. " if last_user else ""
         return f"{prefix}Echo: {text}"
@@ -57,16 +59,22 @@ def load_llm(
         if "awq" in target.lower():
             try:
                 from .awq import AWQLLM
-                return AWQLLM(target)
+                llm = AWQLLM(target)
+                llm.name = target
+                return llm
             except Exception:
                 continue
         try:
             from .hf import HuggingFaceLLM
-            return HuggingFaceLLM(target)
+            llm = HuggingFaceLLM(target)
+            llm.name = target
+            return llm
         except Exception:
             continue
 
-    return EchoLLM()
+    fallback = EchoLLM()
+    fallback.name = "echo"
+    return fallback
 
 # --- Hotfix: ensure EchoLLM fallback does not include the word "echo" ---
 try:


### PR DESCRIPTION
## Summary
- Track actual LLM name during loading and expose it via `BaseLLM.name`
- Update Requiem to use real model names, including friend/alt models
- Show active model in chat interface at startup

## Testing
- `pytest -q` (fails: KeyboardInterrupt/no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68a14fa6e104832da77b14095698a149