### PR TITLE
Add Windows run scripts for Mistral model

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,15 @@
+@echo off
+REM Launch Requiem chat loop with a local Mistral 7B model.
+REM Downloads the model on first run if missing.
+
+setlocal
+
+if not exist "models\mistral" (
+    echo Mistral model not found. Downloading...
+    python download_models.py
+)
+
+set "LLM_MODEL=models\mistral"
+python requiem.py %*
+
+endlocal

--- a/run_web.bat
+++ b/run_web.bat
@@ -1,0 +1,15 @@
+@echo off
+REM Start the Requiem web UI with the local Mistral 7B model.
+REM Downloads the model on first run if missing.
+
+setlocal
+
+if not exist "models\mistral" (
+    echo Mistral model not found. Downloading...
+    python download_models.py
+)
+
+set "LLM_MODEL=models\mistral"
+python web.py %*
+
+endlocal


### PR DESCRIPTION
## Summary
- add `run.bat` to launch Requiem with local Mistral 7B model
- add `run_web.bat` to start the web UI with the same model

## Testing
- `pytest` *(fails: LieEngine.__init__ unexpected keyword)*

------
https://chatgpt.com/codex/tasks/task_e_68a160e05a10832dad2ab23311752d96