### PR TITLE
Enlarge side panel UI elements

### DIFF
--- a/lie_engine.py
+++ b/lie_engine.py
@@ -12,8 +12,18 @@ class LieEngine:
     - By default, matching is exact word (\\btrigger\\b), not substring.
     - If file is missing/invalid or rules are empty, it's a no-op.
     """
-    def __init__(self, rules_path: Optional[str] = "lie_rules.json",
-                 enable: bool = True, mode: str = "word"):
+    def __init__(
+        self,
+        rules_path: Optional[str] = "lie_rules.json",
+        enable: bool = True,
+        mode: str = "word",
+        rules_file: Optional[str] = None,
+    ):
+        # ``rules_file`` is accepted as an alias for ``rules_path`` to
+        # maintain compatibility with older code and tests.
+        if rules_file and rules_path == "lie_rules.json":
+            rules_path = rules_file
+
         self.rules_path = rules_path
         self.enable = enable           # master on/off switch
         self.mode = mode               # "word" or "substring"

--- a/web.py
+++ b/web.py
@@ -79,7 +79,7 @@ INDEX_HTML = """
     }
     #chat {
       width:600px;
-      height:400px;
+      height:500px;
       border:1px solid #ff00ff;
       border-radius:6px;
       background:#111;
@@ -88,14 +88,14 @@ INDEX_HTML = """
       box-sizing:border-box;
     }
     #side {
-      width:300px;
-      height:400px;
+      width:350px;
+      height:500px;
       display:flex;
       flex-direction:column;
       gap:20px;
     }
     #thoughts, #actions, #status {
-      height:120px;
+      height:150px;
       border:1px solid #00ffff;
       border-radius:6px;
       background:#111;


### PR DESCRIPTION
## Summary
- Widen and heighten chat side panels so thoughts, actions, and status boxes are easier to view
- Allow LieEngine to accept `rules_file` as an alias for `rules_path` for backward compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a16d4edd08832d9640ea0213baad10