### PR TITLE
Add simple Flash to JavaScript converter

### DIFF
--- a/flash_converter.py
+++ b/flash_converter.py
@@ -1,0 +1,103 @@
+"""Simple Flash (ActionScript) to JavaScript converter.
+
+This module provides a small `FlashConverter` class capable of converting a
+subset of ActionScript syntax into JavaScript. The goal is not to be a fully
+fledged compiler but to offer a lightweight bridge for legacy Flash snippets.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Union
+
+
+class FlashConverter:
+    """Utility for converting ActionScript code to JavaScript.
+
+    The converter handles a minimal set of transformations that commonly appear
+    in small Flash examples. It performs the following operations:
+
+    * ``trace(...)`` calls become ``console.log(...)``.
+    * ``var`` declarations are replaced with ``let`` and the ActionScript type
+      annotations are removed.
+    * Function return type annotations are stripped.
+    """
+
+    _TYPE_ANNOTATION_RE = re.compile(r":\s*[A-Za-z_][\w]*")
+
+    def convert_code(self, action_script: str) -> str:
+        """Convert an ActionScript source string to JavaScript.
+
+        Parameters
+        ----------
+        action_script:
+            Source code written in ActionScript 3.
+
+        Returns
+        -------
+        str
+            JavaScript code with a limited set of transformations applied.
+        """
+
+        js = action_script
+
+        # Replace trace() calls with console.log()
+        js = re.sub(r"trace\((.*?)\);", r"console.log(\1);", js)
+
+        # Replace 'var' with 'let'
+        js = re.sub(r"\bvar\b", "let", js)
+
+        # Remove type annotations (e.g. ":int", ":String")
+        js = self._TYPE_ANNOTATION_RE.sub("", js)
+
+        # Remove return type annotations in function declarations.
+        js = re.sub(
+            r"function\s+([a-zA-Z_][\w]*)\s*\(([^)]*)\)\s*",  # function head
+            lambda m: f"function {m.group(1)}({m.group(2)}) ",
+            js,
+        )
+
+        return js
+
+    def convert_file(self, src: Union[str, Path], dest: Union[str, Path]) -> None:
+        """Convert an ActionScript file to JavaScript.
+
+        Parameters
+        ----------
+        src, dest:
+            Paths to the source ActionScript file and the destination JavaScript
+            file respectively.
+        """
+
+        src_path = Path(src)
+        dest_path = Path(dest)
+
+        converted = self.convert_code(src_path.read_text())
+        dest_path.write_text(converted)
+
+    def convert_directory(self, src_dir: Union[str, Path], dest_dir: Union[str, Path]) -> None:
+        """Recursively convert all ActionScript files in a directory.
+
+        Parameters
+        ----------
+        src_dir:
+            Directory containing ``.as`` files to convert.
+        dest_dir:
+            Output directory where converted ``.js`` files will be written.
+
+        Notes
+        -----
+        The directory structure of ``src_dir`` is preserved in ``dest_dir``.
+        Only files ending with ``.as`` are considered for conversion. The
+        destination directory is created if it does not already exist.
+        """
+
+        src_root = Path(src_dir)
+        dest_root = Path(dest_dir)
+
+        for src_file in src_root.rglob("*.as"):
+            relative = src_file.relative_to(src_root)
+            dest_file = dest_root / relative.with_suffix(".js")
+            dest_file.parent.mkdir(parents=True, exist_ok=True)
+            self.convert_file(src_file, dest_file)

--- a/test_flash_converter.py
+++ b/test_flash_converter.py
@@ -1,0 +1,73 @@
+import textwrap
+
+from flash_converter import FlashConverter
+
+
+def test_basic_conversion(tmp_path):
+    src_code = textwrap.dedent(
+        """
+        var x:int = 1;
+        trace('hi');
+        function greet(name:String):void {
+            trace(name);
+        }
+        """
+    ).strip()
+
+    converter = FlashConverter()
+    js = converter.convert_code(src_code)
+
+    expected = textwrap.dedent(
+        """
+        let x = 1;
+        console.log('hi');
+        function greet(name) {
+            console.log(name);
+        }
+        """
+    ).strip()
+
+    assert js == expected
+
+    # File based API
+    src_file = tmp_path / "sample.as"
+    dest_file = tmp_path / "sample.js"
+    src_file.write_text(src_code)
+    converter.convert_file(src_file, dest_file)
+    assert dest_file.read_text() == expected
+
+
+def test_directory_conversion(tmp_path):
+    src_root = tmp_path / "src"
+    dest_root = tmp_path / "out"
+    (src_root / "level1").mkdir(parents=True)
+
+    code = textwrap.dedent(
+        """
+        var score:int = 0;
+        function log(msg:String):void {
+            trace(msg);
+        }
+        """
+    ).strip()
+
+    # Create two ActionScript files in different locations
+    file_a = src_root / "main.as"
+    file_b = src_root / "level1" / "helper.as"
+    file_a.write_text(code)
+    file_b.write_text(code)
+
+    converter = FlashConverter()
+    converter.convert_directory(src_root, dest_root)
+
+    expected = textwrap.dedent(
+        """
+        let score = 0;
+        function log(msg) {
+            console.log(msg);
+        }
+        """
+    ).strip()
+
+    assert (dest_root / "main.js").read_text() == expected
+    assert (dest_root / "level1" / "helper.js").read_text() == expected


### PR DESCRIPTION
## Summary
- implement minimal Flash (ActionScript) to JavaScript converter with basic syntax translations
- add tests demonstrating conversion functionality and file-based API
- support bulk directory conversion to handle multiple Flash source files

## Testing
- `pytest test_flash_converter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4b75e8f20832dbe4ebb0baf84e069