### PR TITLE
Improve ActionScript type handling

### DIFF
--- a/test_flash_converter.py
+++ b/test_flash_converter.py
@@ -71,3 +71,28 @@ def test_directory_conversion(tmp_path):
 
     assert (dest_root / "main.js").read_text() == expected
     assert (dest_root / "level1" / "helper.js").read_text() == expected
+
+
+def test_object_literals_and_defaults():
+    src_code = textwrap.dedent(
+        """
+        var settings:Object = {foo: 1, bar: 2};
+        function build(config:Object = {w:10, h:20}):Object {
+            trace(config.w);
+        }
+        """
+    ).strip()
+
+    converter = FlashConverter()
+    js = converter.convert_code(src_code)
+
+    expected = textwrap.dedent(
+        """
+        let settings = {foo: 1, bar: 2};
+        function build(config = {w:10, h:20}) {
+            console.log(config.w);
+        }
+        """
+    ).strip()
+
+    assert js == expected


### PR DESCRIPTION
## Summary
- refine FlashConverter to strip type annotations only in variable declarations, parameter lists, and function returns
- add regression test for object literals and default parameter values

## Testing
- `pytest test_flash_converter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4c9767630832d8f66f25eefe0a327