### PR TITLE
Handle package/import in ActionScript converter

### DIFF
--- a/flash_converter.py
+++ b/flash_converter.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 from typing import Union
+import textwrap
 
 
 class FlashConverter:
@@ -40,6 +41,14 @@ class FlashConverter:
 
         js = action_script
 
+        # Remove package declarations and their wrapping braces
+        if re.search(r"^\s*package\b", js, flags=re.MULTILINE):
+            js = re.sub(r"^\s*package[^\{]*{\s*\n?", "", js, flags=re.MULTILINE)
+            js = re.sub(r"\n}\s*$", "", js)
+
+        # Remove import statements entirely
+        js = re.sub(r"^\s*import [^\n]+(?:\n|$)", "", js, flags=re.MULTILINE)
+
         # Replace trace() calls with console.log(), preserving semicolons if present
         js = re.sub(r"trace\((.*?)\)(;?)", r"console.log(\1)\2", js)
 
@@ -67,7 +76,7 @@ class FlashConverter:
             js,
         )
 
-        return js
+        return textwrap.dedent(js).strip()
 
     def convert_file(self, src: Union[str, Path], dest: Union[str, Path]) -> None:
         """Convert an ActionScript file to JavaScript.

--- a/test_flash_converter.py
+++ b/test_flash_converter.py
@@ -121,3 +121,31 @@ def test_const_and_semicolonless_trace():
     ).strip()
 
     assert js == expected
+
+
+def test_package_and_import_removal():
+    src_code = textwrap.dedent(
+        """
+        package {
+            import flash.utils.Dictionary;
+            var count:int = 0;
+            function inc(val:int):void {
+                trace(val);
+            }
+        }
+        """
+    ).strip()
+
+    converter = FlashConverter()
+    js = converter.convert_code(src_code)
+
+    expected = textwrap.dedent(
+        """
+        let count = 0;
+        function inc(val) {
+            console.log(val);
+        }
+        """
+    ).strip()
+
+    assert js == expected


### PR DESCRIPTION
## Summary
- strip `package` declarations and matching braces
- drop `import` statements before translation
- dedent output to remove leftover indentation
- test package and import removal behavior

## Testing
- `pytest test_flash_converter.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4dab48b60832dbd7e5006e646864a