### PR TITLE
Refine trace conversion and strip access modifiers

### DIFF
--- a/test_flash_converter.py
+++ b/test_flash_converter.py
@@ -123,6 +123,52 @@ def test_const_and_semicolonless_trace():
     assert js == expected
 
 
+def test_trace_with_space_before_parens():
+    src_code = textwrap.dedent(
+        """
+        trace ('a');
+        trace  ('b');
+        trace\t('c');
+        """
+    ).strip()
+
+    converter = FlashConverter()
+    js = converter.convert_code(src_code)
+
+    expected = textwrap.dedent(
+        """
+        console.log('a');
+        console.log('b');
+        console.log('c');
+        """
+    ).strip()
+
+    assert js == expected
+
+
+def test_trace_not_part_of_identifier_or_method():
+    src_code = textwrap.dedent(
+        """
+        mytrace('a');
+        logger.trace('b');
+        trace('c');
+        """
+    ).strip()
+
+    converter = FlashConverter()
+    js = converter.convert_code(src_code)
+
+    expected = textwrap.dedent(
+        """
+        mytrace('a');
+        logger.trace('b');
+        console.log('c');
+        """
+    ).strip()
+
+    assert js == expected
+
+
 def test_package_and_import_removal():
     src_code = textwrap.dedent(
         """
@@ -144,6 +190,103 @@ def test_package_and_import_removal():
         let count = 0;
         function inc(val) {
             console.log(val);
+        }
+        """
+    ).strip()
+
+    assert js == expected
+
+
+def test_access_modifiers_removed():
+    src_code = textwrap.dedent(
+        """
+        public var score:int = 0;
+        private const PI:Number = 3.14;
+        protected function inc(val:int):void {
+            trace(val);
+        }
+        static function count():int {
+            return 0;
+        }
+        """
+    ).strip()
+
+    converter = FlashConverter()
+    js = converter.convert_code(src_code)
+
+    expected = textwrap.dedent(
+        """
+        let score = 0;
+        const PI = 3.14;
+        function inc(val) {
+            console.log(val);
+        }
+        function count() {
+            return 0;
+        }
+        """
+    ).strip()
+
+    assert js == expected
+
+
+def test_for_each_loop_conversion():
+    src_code = textwrap.dedent(
+        """
+        var items:Array = [1, 2, 3];
+        for each (var item in items) {
+            trace(item);
+        }
+        """
+    ).strip()
+
+    converter = FlashConverter()
+    js = converter.convert_code(src_code)
+
+    expected = textwrap.dedent(
+        """
+        let items = [1, 2, 3];
+        for (let item of items) {
+            console.log(item);
+        }
+        """
+    ).strip()
+
+    assert js == expected
+
+
+def test_class_implements_removed():
+    src_code = textwrap.dedent(
+        """
+        public class MySprite extends Sprite implements IFoo, IBar {
+            public function MySprite() {
+                trace('hi');
+            }
+        }
+
+        internal class Simple implements IThing {
+            public function Simple() {
+                trace('x');
+            }
+        }
+        """
+    ).strip()
+
+    converter = FlashConverter()
+    js = converter.convert_code(src_code)
+
+    expected = textwrap.dedent(
+        """
+        class MySprite extends Sprite {
+            function MySprite() {
+                console.log('hi');
+            }
+        }
+
+        class Simple {
+            function Simple() {
+                console.log('x');
+            }
         }
         """
     ).strip()


### PR DESCRIPTION
## Summary
- Strip ActionScript access modifiers like `public` or `static` so generated JavaScript is syntactically valid
- Document and test the new modifier-removal feature alongside existing trace handling
- Translate ActionScript `for each` loops into JavaScript `for...of` constructs
- Remove `implements` clauses from class declarations to prevent unsupported interface syntax

## Testing
- `pytest test_flash_converter.py::test_class_implements_removed -q`
- `pytest test_flash_converter.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4df303c38832d817c71e61eb3635d